### PR TITLE
fix(perf): sampling should at least produce one result

### DIFF
--- a/crates/gungraun-runner/fixtures/mod.rs
+++ b/crates/gungraun-runner/fixtures/mod.rs
@@ -346,7 +346,7 @@ pub fn tool_command_f(
 pub fn tool_command_child_f(
     exe: &Path,
     args: Option<&[&str]>,
-    log_path: ToolOutputPath,
+    output_path: ToolOutputPath,
     tool: Option<Tool>,
     exit_with: Option<ExitWith>,
     stdout: Option<StdStdio>,
@@ -362,7 +362,7 @@ pub fn tool_command_child_f(
         child,
         path,
         exit_with,
-        log_path,
+        output_path,
         None,
     )
 }

--- a/crates/gungraun-runner/src/api.rs
+++ b/crates/gungraun-runner/src/api.rs
@@ -1681,7 +1681,8 @@ pub struct PerfSpec {
     pub run_mode: Option<PerfRunMode>,
     /// The timeout used for sampled perf runs.
     ///
-    /// Setting this enables sampling mode for `perf stat`.
+    /// Setting this enables sampling mode for `perf stat`. The duration is only applied once at
+    /// least one sample has been recorded, guaranteeing at least one sample per run.
     pub sample_duration: Option<Duration>,
 }
 

--- a/crates/gungraun-runner/src/runner/perf/run.rs
+++ b/crates/gungraun-runner/src/runner/perf/run.rs
@@ -183,6 +183,7 @@ impl<'a> PerfCalibration<'a> {
             &Arc::new(AtomicBool::new(false)),
             Duration::from_millis(10),
             Some(Duration::ZERO),
+            None::<&fn() -> bool>,
         )?;
 
         check_exit(

--- a/crates/gungraun-runner/src/runner/tasks.rs
+++ b/crates/gungraun-runner/src/runner/tasks.rs
@@ -206,9 +206,10 @@ impl ProcessChild {
     /// Waits for the child process to exit while polling [`std::process::Child::try_wait`].
     ///
     /// The method consumes the wrapped [`std::process::Child`] and repeatedly polls it until the
-    /// process exits. It sleeps for `poll_interval` between polls and, when `timeout` is set,
-    /// sends SIGTERM after the timeout elapses. If `force_shutdown` becomes set, it also sends
-    /// SIGTERM and returns [`Error::TaskInterrupt`] once the process stops.
+    /// process exits. It sleeps for `poll_interval` between polls and, when `timeout` is set, sends
+    /// SIGTERM after the timeout elapses and the optional `is_ready` predicate returns `true`. This
+    /// gates the timeout on readiness. If `force_shutdown` becomes set, it also sends SIGTERM and
+    /// returns [`Error::TaskInterrupt`] once the process stops.
     ///
     /// Shutdown follows a three-state machine: `Running` polls the child, `Term` waits up to
     /// 100 poll cycles after SIGTERM, and `Kill` sends SIGKILL via [`std::process::Child::kill`]
@@ -227,12 +228,16 @@ impl ProcessChild {
     /// - The process is interrupted by `force_shutdown` ([`Error::TaskInterrupt`])
     ///
     /// [`Error::TaskInterrupt`]: crate::error::Error::TaskInterrupt
-    pub fn wait(
+    pub fn wait<F>(
         self,
         force_shutdown: &Arc<AtomicBool>,
         poll_interval: Duration,
         timeout: Option<Duration>,
-    ) -> Result<Output> {
+        is_ready: Option<&F>,
+    ) -> Result<Output>
+    where
+        F: Fn() -> bool,
+    {
         let send_sigterm = |id: u32| -> Result<()> {
             let pid_t = i32::try_from(id)?;
             let pid = Pid::from_raw(pid_t);
@@ -265,7 +270,10 @@ impl ProcessChild {
                             run_state = ProcessState::Term;
                             interrupted = true;
                         }
-                        ProcessState::Running if timeout.is_some_and(|t| start.elapsed() >= t) => {
+                        ProcessState::Running
+                            if timeout.is_some_and(|t| start.elapsed() >= t)
+                                && is_ready.is_none_or(|is_ready| is_ready()) =>
+                        {
                             send_sigterm(child.id())?;
 
                             run_state = ProcessState::Term;
@@ -431,6 +439,9 @@ impl ProcessHandler {
     /// while periodically checking the shared `force_shutdown` flag. If shutdown is requested, the
     /// benchmark process is sent SIGTERM, followed by SIGKILL if it doesn't terminate gracefully.
     ///
+    /// If `timeout` is set, the benchmark process is stopped with SIGTERM once the timeout has
+    /// elapsed and the optional `is_ready` predicate returns `true`.
+    ///
     /// After the benchmark process exits, the exit status is validated against the configured
     /// expectations in [`ExitWith`] if present. Finally, if a setup assistant is still running,
     /// this method waits for it to complete and propagates any setup error.
@@ -454,30 +465,42 @@ impl ProcessHandler {
     ///
     /// [`ExitWith`]: crate::api::ExitWith
     /// [`Error::TaskInterrupt`]: crate::error::Error::TaskInterrupt
-    pub fn wait_or_shutdown(&mut self, timeout: Option<Duration>) -> Result<Output> {
+    pub fn wait_or_shutdown<F>(
+        &mut self,
+        timeout: Option<Duration>,
+        is_ready: &Option<F>,
+    ) -> Result<Output>
+    where
+        F: Fn() -> bool,
+    {
         let mut bench_child = self
             .bench
             .take()
             .expect("A benchmark should be started before waiting");
 
         debug!("Waiting for the {} child process", bench_child.tool);
-        let result = ProcessChild(
-            bench_child
-                .child
-                .take()
-                .expect("A child process should be present"),
-        )
-        .wait(&self.force_shutdown, self.poll_interval, timeout)
-        .with_context(|| "Trying to wait for the benchmark process to stop")
-        .and_then(|output| {
-            check_exit(
-                bench_child.tool,
-                &bench_child.executable,
-                output,
-                &bench_child.log_path,
-                bench_child.exit_with.as_ref(),
+        let child = bench_child
+            .child
+            .take()
+            .expect("A child process should be present");
+
+        let result = ProcessChild(child)
+            .wait(
+                &self.force_shutdown,
+                self.poll_interval,
+                timeout,
+                is_ready.as_ref(),
             )
-        });
+            .with_context(|| "Trying to wait for the benchmark process to stop")
+            .and_then(|output| {
+                check_exit(
+                    bench_child.tool,
+                    &bench_child.executable,
+                    output,
+                    &bench_child.output_path.to_log_output(),
+                    bench_child.exit_with.as_ref(),
+                )
+            });
 
         if let Some(Err(error)) = self.wait_for_setup() {
             return Err(error);
@@ -488,7 +511,12 @@ impl ProcessHandler {
 
     fn wait_for_assistant(&self, child: Child, id: &str) -> Result<()> {
         ProcessChild(child)
-            .wait(&self.force_shutdown, self.poll_interval, None)
+            .wait(
+                &self.force_shutdown,
+                self.poll_interval,
+                None,
+                None::<&fn() -> bool>,
+            )
             .with_context(|| format!("Trying to wait for the {id} process to stop"))
             .and_then(|output| {
                 let status = output.status;
@@ -762,6 +790,9 @@ impl<T: Send + 'static> Iterator for ThreadPool<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::Command;
+
     use rstest::rstest;
 
     use super::*;
@@ -770,6 +801,32 @@ mod tests {
     use crate::runner::common::ModulePath;
     use crate::runner::lib_bench::{self, LibBench};
     const DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
+
+    #[test]
+    fn test_process_child_wait_with_timeout_waits_for_readiness() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("perf.out");
+        let delayed_output_path = output_path.clone();
+        let output_thread = thread::spawn(move || {
+            sleep(Duration::from_millis(50));
+            std::fs::File::create(delayed_output_path).unwrap();
+        });
+        let child = Command::new("sleep").arg("1").spawn().unwrap();
+        let start = Instant::now();
+
+        let output = ProcessChild(child)
+            .wait(
+                &Arc::new(AtomicBool::new(false)),
+                Duration::from_millis(1),
+                Some(Duration::from_millis(10)),
+                Some(&|| output_path.exists()),
+            )
+            .unwrap();
+
+        output_thread.join().unwrap();
+        assert!(start.elapsed() >= Duration::from_millis(50));
+        assert_eq!(output.status.signal(), Some(signal::SIGTERM as i32));
+    }
 
     #[rstest]
     #[case::size_one_jobs_zero(1, 0)]

--- a/crates/gungraun-runner/src/runner/tool/config.rs
+++ b/crates/gungraun-runner/src/runner/tool/config.rs
@@ -170,7 +170,9 @@ pub struct ToolConfig {
     ///
     /// For perf, this stores the `sample_duration` when sampling is enabled. It is cleared for
     /// paired record configs because the sample duration applies to the stat measurement, not the
-    /// record run.
+    /// record run. The duration is only applied once the perf output contains at least one
+    /// sample, so a sampled run always records at least one sample and may exceed the configured
+    /// duration until the first sample is written.
     ///
     /// Note this is a timeout that is expected to happen and not only a cap that might trigger.
     pub timeout: Option<Duration>,
@@ -1063,7 +1065,20 @@ impl ToolConfigs {
                     captured_output,
                     config.meta.args.tool_runner_dest.as_deref(),
                 )
-                .and_then(|()| process_handler.wait_or_shutdown(tool_config.timeout))?;
+                .and_then(|()| {
+                    // For sampled perf runs, gate the timeout on a non-empty output file: the
+                    // duration only applies after the first sample was written, ensuring there
+                    // is always at least one sample.
+                    let readiness_path = (tool_config.tool() == Tool::Perf
+                        && tool_config.timeout.is_some())
+                    .then(|| output_path.to_path());
+
+                    let is_ready = readiness_path.as_ref().map(|path| {
+                        move || std::fs::metadata(path).is_ok_and(|metadata| metadata.len() > 0)
+                    });
+
+                    process_handler.wait_or_shutdown(tool_config.timeout, &is_ready)
+                })?;
 
             if let ToolConfigOptions::Perf(options) = &tool_config.options
                 && matches!(

--- a/crates/gungraun-runner/src/runner/tool/run.rs
+++ b/crates/gungraun-runner/src/runner/tool/run.rs
@@ -87,8 +87,8 @@ pub struct ToolCommandChild {
     pub executable: PathBuf,
     /// The expected exit behavior (exit code or signal), or `None` if any exit is acceptable
     pub exit_with: Option<ExitWith>,
-    /// The path where Valgrind will write its output log files
-    pub log_path: ToolOutputPath,
+    /// The path where the tool will write its normal output files.
+    pub output_path: ToolOutputPath,
     /// Keeps the parent-side perf descriptors alive for the lifetime of the running tool process.
     pub perf_data: Option<PerfData>,
     /// The tool running this process (e.g., Memcheck, Callgrind, Massif)
@@ -276,43 +276,42 @@ impl ToolCommand {
 
         let executable_args = executable_args_fn(config, None);
 
-        let (mut perf_data, args, log_path) =
-            if let ToolConfigOptions::Perf(options) = &config.options {
-                if let Some(time) = match options.run_mode {
-                    PerfRunMode::DefaultCalibrate => Some(DEFAULT_PERF_CALIBRATION_TIME),
-                    PerfRunMode::Calibrate(time) => Some(time),
-                    _ => None,
-                } {
-                    let calibration_args =
-                        executable_args_fn(config, Some(BenchRunMode::PerfCalibrate));
-                    PerfCalibration::new(
-                        &self,
-                        config,
-                        &calibration_args,
-                        output_path,
-                        time,
-                        tool_runner_dest,
-                    )
-                    .run()?;
-                }
-
-                prepare_perf_command(
-                    &mut self.command,
+        let (mut perf_data, args) = if let ToolConfigOptions::Perf(options) = &config.options {
+            if let Some(time) = match options.run_mode {
+                PerfRunMode::DefaultCalibrate => Some(DEFAULT_PERF_CALIBRATION_TIME),
+                PerfRunMode::Calibrate(time) => Some(time),
+                _ => None,
+            } {
+                let calibration_args =
+                    executable_args_fn(config, Some(BenchRunMode::PerfCalibrate));
+                PerfCalibration::new(
+                    &self,
                     config,
+                    &calibration_args,
                     output_path,
-                    options.use_sampling,
+                    time,
                     tool_runner_dest,
                 )
-                .map(|(perf_data, tool_args, log_path)| (Some(perf_data), tool_args, log_path))?
-            } else {
-                let mut tool_args = config.args.clone();
-                tool_args.set_output_arg(output_path, tool_runner_dest);
-                tool_args.set_log_arg(output_path, tool_runner_dest);
-                tool_args.set_xtree_arg(output_path, tool_runner_dest);
-                tool_args.set_xleak_arg(output_path, tool_runner_dest);
+                .run()?;
+            }
 
-                (None, tool_args.to_vec(), output_path.to_log_output())
-            };
+            prepare_perf_command(
+                &mut self.command,
+                config,
+                output_path,
+                options.use_sampling,
+                tool_runner_dest,
+            )
+            .map(|(perf_data, tool_args, _)| (Some(perf_data), tool_args))?
+        } else {
+            let mut tool_args = config.args.clone();
+            tool_args.set_output_arg(output_path, tool_runner_dest);
+            tool_args.set_log_arg(output_path, tool_runner_dest);
+            tool_args.set_xtree_arg(output_path, tool_runner_dest);
+            tool_args.set_xleak_arg(output_path, tool_runner_dest);
+
+            (None, tool_args.to_vec())
+        };
 
         debug!(
             "{}: Tool arguments: {}",
@@ -379,7 +378,7 @@ impl ToolCommand {
                     c,
                     self.executable,
                     exit_with,
-                    log_path,
+                    output_path.clone(),
                     perf_data,
                 ))
             })
@@ -439,21 +438,21 @@ impl ToolCommandChild {
     /// This constructor wraps a spawned child process along with metadata needed to track and
     /// manage its execution. The `tool` parameter specifies which [`Tool`] is being run,
     /// `child` is the actual spawned process, `executable` is the path to the binary being
-    /// instrumented, `exit_with` defines the expected exit behavior, and `log_path` specifies
-    /// where the tool's output is written.
+    /// instrumented, `exit_with` defines the expected exit behavior, `output_path` specifies where
+    /// the tool writes its output.
     pub fn new(
         tool: Tool,
         child: Child,
         executable: PathBuf,
         exit_with: Option<ExitWith>,
-        log_path: ToolOutputPath,
+        output_path: ToolOutputPath,
         perf_data: Option<PerfData>,
     ) -> Self {
         Self {
             child: Some(child),
             executable,
             exit_with,
-            log_path,
+            output_path,
             tool,
             perf_data,
         }

--- a/crates/gungraun-tests/benches/test_lib_bench/perf/expected_files.1.yml
+++ b/crates/gungraun-tests/benches/test_lib_bench/perf/expected_files.1.yml
@@ -348,6 +348,14 @@ data:
         - perf.iter.two_to_four_2.out
         - summary.json
   - group: with_sampling
+    function: long_time
+    id: two
+    expected:
+      files:
+        - perf.long_time.two.log
+        - perf.long_time.two.out
+        - summary.json
+  - group: with_sampling
     function: with_consts
     id: one_thousand
     expected:
@@ -555,6 +563,14 @@ data:
       files:
         - perf.iter.two_to_four_2.log
         - perf.iter.two_to_four_2.out
+        - summary.json
+  - group: without_sampling
+    function: long_time
+    id: two
+    expected:
+      files:
+        - perf.long_time.two.log
+        - perf.long_time.two.out
         - summary.json
   - group: without_sampling
     function: with_consts

--- a/crates/gungraun-tests/benches/test_lib_bench/perf/expected_files.2.yml
+++ b/crates/gungraun-tests/benches/test_lib_bench/perf/expected_files.2.yml
@@ -506,6 +506,16 @@ data:
         - perf.iter.two_to_four_2.out.old
         - summary.json
   - group: with_sampling
+    function: long_time
+    id: two
+    expected:
+      files:
+        - perf.long_time.two.log
+        - perf.long_time.two.log.old
+        - perf.long_time.two.out
+        - perf.long_time.two.out.old
+        - summary.json
+  - group: with_sampling
     function: with_consts
     id: one_thousand
     expected:
@@ -785,6 +795,16 @@ data:
         - perf.iter.two_to_four_2.log.old
         - perf.iter.two_to_four_2.out
         - perf.iter.two_to_four_2.out.old
+        - summary.json
+  - group: without_sampling
+    function: long_time
+    id: two
+    expected:
+      files:
+        - perf.long_time.two.log
+        - perf.long_time.two.log.old
+        - perf.long_time.two.out
+        - perf.long_time.two.out.old
         - summary.json
   - group: without_sampling
     function: with_consts

--- a/crates/gungraun-tests/benches/test_lib_bench/perf/expected_stdout.1
+++ b/crates/gungraun-tests/benches/test_lib_bench/perf/expected_stdout.1
@@ -174,6 +174,13 @@ test_lib_bench_perf::without_sampling::iter two_to_four_2:(nth of 2 ..= 4)
   cpu-clock/u:                                            |N/A                  (*********)
   faults/u:                                               |N/A                  (*********)
   context-switches/u:                                     |N/A                  (*********)
+test_lib_bench_perf::without_sampling::long_time two:(Duration :: from_secs(3))
+  ======= PERF ========================================================================================
+  >> alpha: 0.05000, min_pcnt_running: 100.000
+  task-clock/u:                                           |N/A                  (*********)
+  cpu-clock/u:                                            |N/A                  (*********)
+  faults/u:                                               |N/A                  (*********)
+  context-switches/u:                                     |N/A                  (*********)
 test_lib_bench_perf::with_sampling::event_sets default:(1000)
   ======= PERF ========================================================================================
   >> alpha: 0.05000, min_pcnt_running: 100.000
@@ -474,6 +481,13 @@ test_lib_bench_perf::with_sampling::iter two_to_four_2:(nth of 2 ..= 4)
   context-switches/u:                                     |N/A                  (*********)
     rse% (sig.thr) [sig.fact]                             |N/A                  (*********)
     samples                                               |N/A                  (*********)
+test_lib_bench_perf::with_sampling::long_time two:(Duration :: from_secs(3))
+  ======= PERF ========================================================================================
+  >> alpha: 0.05000, min_pcnt_running: 100.000
+  task-clock/u:                                           |N/A                  (*********)
+  cpu-clock/u:                                            |N/A                  (*********)
+  faults/u:                                               |N/A                  (*********)
+  context-switches/u:                                     |N/A                  (*********)
 test_lib_bench_perf::record::event_sets default:(1000)
   ======= PERF ========================================================================================
   >> alpha: 0.05000, min_pcnt_running: 100.000
@@ -574,4 +588,4 @@ test_lib_bench_perf::record::disabled_entry_point_without_measurement
   ======= PERF ========================================================================================
   Empty data
 
-Gungraun result: Ok. 60 without regressions; 0 regressed; 0 filtered; 60 benchmarks finished in <__SECONDS__>s
+Gungraun result: Ok. 62 without regressions; 0 regressed; 0 filtered; 62 benchmarks finished in <__SECONDS__>s

--- a/crates/gungraun-tests/benches/test_lib_bench/perf/expected_stdout.2
+++ b/crates/gungraun-tests/benches/test_lib_bench/perf/expected_stdout.2
@@ -174,6 +174,13 @@ test_lib_bench_perf::without_sampling::iter two_to_four_2:(nth of 2 ..= 4)
   cpu-clock/u:                                            |                     (        %) [        x]
   faults/u:                                               |                     (        %) [        x]
   context-switches/u:                                     |                     (        %) [        x]
+test_lib_bench_perf::without_sampling::long_time two:(Duration :: from_secs(3))
+  ======= PERF ========================================================================================
+  >> alpha: 0.05000, min_pcnt_running: 100.000
+  task-clock/u:                                           |                     (        %) [        x]
+  cpu-clock/u:                                            |                     (        %) [        x]
+  faults/u:                                               |                     (        %) [        x]
+  context-switches/u:                                     |                     (        %) [        x]
 test_lib_bench_perf::with_sampling::event_sets default:(1000)
   ======= PERF ========================================================================================
   >> alpha: 0.05000, min_pcnt_running: 100.000
@@ -474,6 +481,13 @@ test_lib_bench_perf::with_sampling::iter two_to_four_2:(nth of 2 ..= 4)
   context-switches/u:                                     |                     (        %) [        x]
     rse% (sig.thr) [sig.fact]                             |                     (*********)
     samples                                               |                     (        %) [        x]
+test_lib_bench_perf::with_sampling::long_time two:(Duration :: from_secs(3))
+  ======= PERF ========================================================================================
+  >> alpha: 0.05000, min_pcnt_running: 100.000
+  task-clock/u:                                           |                     (        %) [        x]
+  cpu-clock/u:                                            |                     (        %) [        x]
+  faults/u:                                               |                     (        %) [        x]
+  context-switches/u:                                     |                     (        %) [        x]
 test_lib_bench_perf::record::event_sets default:(1000)
   ======= PERF ========================================================================================
   >> alpha: 0.05000, min_pcnt_running: 100.000
@@ -574,4 +588,4 @@ test_lib_bench_perf::record::disabled_entry_point_without_measurement
   ======= PERF ========================================================================================
   Empty data
 
-Gungraun result: Ok. 60 without regressions; 0 regressed; 0 filtered; 60 benchmarks finished in <__SECONDS__>s
+Gungraun result: Ok. 62 without regressions; 0 regressed; 0 filtered; 62 benchmarks finished in <__SECONDS__>s

--- a/crates/gungraun-tests/benches/test_lib_bench/perf/test_lib_bench_perf.conf.yml
+++ b/crates/gungraun-tests/benches/test_lib_bench/perf/test_lib_bench_perf.conf.yml
@@ -22,6 +22,8 @@
 #   - Default, sampling, recording, and calibration execution modes
 #     (`DefaultCalibrate`, `Calibrate(1s)`), partly combined with
 #     `record_args`
+#   - Sampling mode with a benchmark runtime that is larger than the sampling
+#     time
 #   - Perf combined with Callgrind as default or additional tool, including
 #     explicitly disabled Perf
 #   - Benchmarks with a disabled entry point; one is measured selectively via
@@ -40,6 +42,8 @@
 #     (once without sampling or recording, appended while sampling)
 #   - The `dummy`-metric, selectively unmeasured, and empty-range benchmarks
 #     produce empty data sets without errors or panics
+#   - If the sampling time is lower than the actual benchmark runtime then there
+#     is still at least one sample produced.
 #   - FreeBSD doesn't run Perf, skips benchmarks which have only perf configured
 #     and uses the non-Perf fallback expectations
 

--- a/crates/gungraun-tests/benches/test_lib_bench/perf/test_lib_bench_perf.rs
+++ b/crates/gungraun-tests/benches/test_lib_bench/perf/test_lib_bench_perf.rs
@@ -186,6 +186,12 @@ fn iter(arg: i32) -> Vec<i32> {
     black_box(bubble_sort(setup_worst_case_array(black_box(arg))))
 }
 
+#[library_benchmark]
+#[bench::two(Duration::from_secs(3))]
+fn long_time(time: Duration) {
+    std::thread::sleep(black_box(time));
+}
+
 library_benchmark_group!(
     name = without_sampling,
     benchmarks = [
@@ -195,7 +201,8 @@ library_benchmark_group!(
         disabled_entry_point_without_measurement,
         generic,
         with_consts,
-        iter
+        iter,
+        long_time
     ]
 );
 
@@ -210,7 +217,8 @@ library_benchmark_group!(
         disabled_entry_point_without_measurement,
         generic,
         with_consts,
-        iter
+        iter,
+        long_time
     ]
 );
 

--- a/crates/gungraun-tests/tests/test_tasks/test_process_handler.rs
+++ b/crates/gungraun-tests/tests/test_tasks/test_process_handler.rs
@@ -371,7 +371,7 @@ fn test_start_bench_when_setup_not_parallel_with_error_then_no_bench_and_setup_e
 #[should_panic = "A benchmark should be started before waiting"]
 fn test_wait_or_shutdown_when_no_bench_then_panic() {
     let mut handler = process_handler_f().fx();
-    let _ = handler.wait_or_shutdown(None);
+    let _ = handler.wait_or_shutdown(None, &None::<fn() -> bool>);
 }
 
 #[rstest]
@@ -384,12 +384,11 @@ fn test_wait_or_shutdown_when_force_shutdown_is_false(#[case] has_setup: bool) {
         .exe(&ECHO_EXE)
         .args(&["foo"])
         .stdout(StdStdio::piped())
-        .log_path(
+        .output_path(
             tool_output_path_f()
                 .target_dir(test_dir.path())
                 .init(true)
-                .fx()
-                .to_log_output(),
+                .fx(),
         )
         .fx();
 
@@ -403,7 +402,7 @@ fn test_wait_or_shutdown_when_force_shutdown_is_false(#[case] has_setup: bool) {
     };
 
     let output = handler
-        .wait_or_shutdown(None)
+        .wait_or_shutdown(None, &None::<fn() -> bool>)
         .expect("Waiting for the benchmark process should succeed");
 
     assert!(handler.bench.is_none());
@@ -422,7 +421,7 @@ fn test_wait_or_shutdown_when_force_shutdown_is_true_then_interrupt(#[case] has_
     let tool_command_child = tool_command_child_f()
         .exe(&TIMEOUT_EXE)
         .args(&["5000"])
-        .log_path(
+        .output_path(
             tool_output_path_f()
                 .target_dir(test_dir.path())
                 .init(true)
@@ -448,7 +447,7 @@ fn test_wait_or_shutdown_when_force_shutdown_is_true_then_interrupt(#[case] has_
     let error = assert_not_elapsed!(
         Duration::from_millis(500),
         handler
-            .wait_or_shutdown(None)
+            .wait_or_shutdown(None, &None::<fn() -> bool>)
             .expect_err("An error should be present")
             .downcast::<Error>()
             .expect("The error should be a gungraun error")
@@ -470,7 +469,7 @@ fn test_wait_or_shutdown_when_error_in_setup_then_setup_error(#[case] exit_code:
     let tool_command_child = tool_command_child_f()
         .exe(&EXIT_WITH_EXE)
         .args(&[&exit_code.to_string()])
-        .log_path(
+        .output_path(
             tool_output_path_f()
                 .target_dir(test_dir.path())
                 .init(true)
@@ -490,7 +489,7 @@ fn test_wait_or_shutdown_when_error_in_setup_then_setup_error(#[case] exit_code:
         .fx();
 
     let result = handler
-        .wait_or_shutdown(None)
+        .wait_or_shutdown(None, &None::<fn() -> bool>)
         .expect_err("An error should be present")
         .downcast::<Error>()
         .expect("The error should be a gungraun error");
@@ -525,7 +524,7 @@ fn test_wait_or_shutdown_when_exit_with(#[case] exit_with_code: i32) {
         .exe(&EXIT_WITH_EXE)
         .args(&[&exit_with_code.to_string()])
         .exit_with(exit_with)
-        .log_path(
+        .output_path(
             tool_output_path_f()
                 .target_dir(test_dir.path())
                 .init(true)
@@ -537,7 +536,7 @@ fn test_wait_or_shutdown_when_exit_with(#[case] exit_with_code: i32) {
     let mut handler = process_handler_f().bench(tool_command_child).fx();
 
     let output = handler
-        .wait_or_shutdown(None)
+        .wait_or_shutdown(None, &None::<fn() -> bool>)
         .expect("Waiting for the benchmark to exit with the expected code should succeed");
 
     assert!(handler.bench.is_none());
@@ -561,7 +560,7 @@ fn test_wait_or_shutdown_when_exit_with_no_match_then_error() {
         .exe(&EXIT_WITH_EXE)
         .args(&[&actual_exit_code.to_string()])
         .exit_with(ExitWith::Code(222))
-        .log_path(
+        .output_path(
             tool_output_path_f()
                 .target_dir(test_dir.path())
                 .init(true)
@@ -573,7 +572,7 @@ fn test_wait_or_shutdown_when_exit_with_no_match_then_error() {
     let mut handler = process_handler_f().bench(tool_command_child).fx();
 
     let error = handler
-        .wait_or_shutdown(None)
+        .wait_or_shutdown(None, &None::<fn() -> bool>)
         .expect_err(
             "There should be an error if the actual exit code does not match the `ExitWith` code",
         )

--- a/crates/gungraun/src/common.rs
+++ b/crates/gungraun/src/common.rs
@@ -2648,6 +2648,10 @@ impl Perf {
     /// independent from the duration supplied to [`PerfRunMode::Calibrate`], which controls a
     /// separate calibration pass.
     ///
+    /// The duration is only applied once at least one sample has been recorded: a run is never
+    /// stopped before its first sample, so every run produces at least one sample, but it may
+    /// exceed the configured duration until the first sample is written.
+    ///
     /// If the sampling duration is long enough for multiple benchmark runs, the first run is
     /// discarded to mitigate cold-start effects. However, there is always at least one record
     /// kept. For example, if a benchmark run takes 1s and the sampling duration is 2s, two runs


### PR DESCRIPTION
Sampled perf runs failed with `Error: A new dataset should always be present` whenever a
benchmark's runtime exceeded the configured `sample_duration`. For example, a benchmark
sleeping 3s under `sample_duration(1s)` reliably reproduced the failure: the runner
SIGTERMed `perf stat` mid-repeat, perf never flushed a result, and the JSON parser found an
empty dataset.

### Fix

`sample_duration` is now a *minimum*: a sampled run is never stopped before its first sample.

### Also in this PR

- Docs updated to state the minimum-duration semantics on both `PerfSpec::sample_duration`
  (runner API) and `Perf::sample_duration` (public API).
- System-test fixture `test_lib_bench_perf`: new `long_time` benchmark (sleeps 3s) added to
  the `without_sampling` and `with_sampling` (`sample_duration(1s)`) groups, covering the
  runtime-exceeds-sample-duration case; `.conf.yml` comments updated to match.
