### PR TITLE
fix(perf): metric patterns should normalize to displayed metric names

### DIFF
--- a/crates/gungraun-runner/src/api.rs
+++ b/crates/gungraun-runner/src/api.rs
@@ -1634,7 +1634,6 @@ pub struct OutputFormat {
 /// Identifies a perf metric by the event name emitted in the parsed summary.
 ///
 /// Perf metrics are far too numerous to use an enum as usual with each event being a variant.
-#[expect(clippy::unsafe_derive_deserialize)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct PerfMetric(pub String);
@@ -2583,27 +2582,9 @@ impl PerfMetric {
     }
 
     /// Return a display-oriented copy of this perf metric name.
-    ///
-    /// Perf metric names may use `:` as an internal separator and can end with trailing separators.
-    /// This replaces `:` with `/` and trims trailing `/` characters for terminal output.
+    #[cfg(feature = "runner")]
     pub fn display(&self) -> Self {
-        let mut display = self.0.clone();
-
-        // SAFETY: `:` and `/` are both single ASCII bytes. Replacing `:` with `/` preserves the
-        // string's length and UTF-8 validity, since ASCII bytes are valid single-byte UTF-8 code
-        // units.
-        let bytes = unsafe { display.as_bytes_mut() };
-        for b in bytes.iter_mut() {
-            if *b == b':' {
-                *b = b'/';
-            }
-        }
-
-        if let Some(new_len) = display.bytes().rposition(|b| b != b'/').map(|i| i + 1) {
-            display.truncate(new_len);
-        }
-
-        Self(display)
+        Self(crate::runner::perf::pattern::normalize(&self.0))
     }
 }
 
@@ -3243,6 +3224,15 @@ mod tests {
     use crate::fixtures::api::dhat_spec_f;
     use crate::fixtures::perf::perf_spec_f;
     use crate::fixtures::tool_spec_f;
+
+    #[cfg(feature = "runner")]
+    #[test]
+    fn test_perf_metric_display_normalizes_separators() {
+        assert_eq!(
+            PerfMetric::from("task-clock:").display().name(),
+            "task-clock"
+        );
+    }
 
     #[rstest]
     #[case::default("d:d:000000", Some(BenchRunMode::Default))]

--- a/crates/gungraun-runner/src/runner/args.rs
+++ b/crates/gungraun-runner/src/runner/args.rs
@@ -504,6 +504,8 @@ pub struct CommandLineArgs {
     ///   * exp-bbv
     ///   * perf
     ///
+    /// The selected tool must be supported on the benchmark target.
+    ///
     /// This argument matches the tool case-insensitive. Note that using Cachegrind with this
     /// option to benchmark library functions needs adjustments to the benchmarking functions with
     /// client-requests to measure the counts correctly. If you want to switch permanently to
@@ -1131,9 +1133,12 @@ pub struct CommandLineArgs {
     /// such as `ms`, `s`, `B`, or `Hz` is a hard limit. Combine soft and hard limits for one
     /// pattern with `|`.
     ///
+    /// In perf metric patterns, `:` and `/` are interchangeable.
+    ///
     /// Examples:
     ///   * --perf-limits='*instructions*=5%'
     ///   * --perf-limits='*instructions*=5%|1000000,task-clock*=40%|2.5ms'
+    ///   * --perf-limits='task-clock/u=5%' or --perf-limits='task-clock:u=5%'
     #[arg(
         display_order = 600,
         env = "GUNGRAUN_PERF_LIMITS",
@@ -1574,6 +1579,10 @@ pub struct CommandLineArgs {
     /// The tools specified here take precedence over the tools in the benchmarks. The supported
     /// tools which are allowed here are the same as the ones listed in the documentation of
     /// --default-tool.
+    ///
+    /// Target-unsupported tools are omitted from a benchmark's resolved tool configurations. For
+    /// example if `perf` is not available on the target then `perf` benchmarks are ignored. All
+    /// Valgrind benchmarks are executed as usual.
     ///
     /// Examples
     ///   * --tools dhat

--- a/crates/gungraun-runner/src/runner/perf/mod.rs
+++ b/crates/gungraun-runner/src/runner/perf/mod.rs
@@ -12,6 +12,7 @@ pub mod args;
 pub mod json_parser;
 pub mod logfile_parser;
 pub mod model;
+pub mod pattern;
 pub mod records;
 pub mod regression;
 pub mod run;

--- a/crates/gungraun-runner/src/runner/perf/pattern.rs
+++ b/crates/gungraun-runner/src/runner/perf/pattern.rs
@@ -1,0 +1,70 @@
+//! Wildcard matching of perf metric names against user-provided patterns.
+
+use simplematch::{DoWild, Options};
+
+const DOWILD_OPTIONS: Options<u8> = Options::new()
+    .case_insensitive(true)
+    .enable_escape(true)
+    .enable_classes(true);
+
+/// Returns whether a perf metric name matches a wildcard pattern.
+///
+/// Both sides are matched case-insensitively with `*`, `?`, and `[...]` character classes; `\`
+/// escapes a wildcard character.
+///
+/// `:` and `/` are treated as equivalent separators: both sides are normalized to `/` before
+/// matching, so a pattern like `task-clock/u` matches the perf metric `task-clock:u` and vice
+/// versa.
+pub fn matches(pattern: &str, metric: &str) -> bool {
+    let pattern = normalize(pattern);
+    let metric = normalize(metric);
+
+    pattern.dowild_with(metric, DOWILD_OPTIONS)
+}
+
+/// Normalizes perf metric separators
+pub fn normalize(value: &str) -> String {
+    value.trim_end_matches(['/', ':']).bytes().fold(
+        String::with_capacity(value.len()),
+        |mut acc, byte| {
+            if byte == b':' {
+                acc.push('/');
+            } else {
+                acc.push(byte as char);
+            }
+            acc
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::{matches, normalize};
+
+    #[test]
+    fn test_normalize_separator_strips_trailing_separators() {
+        assert_eq!(normalize("task-clock:"), "task-clock");
+        assert_eq!(normalize("task-clock/"), "task-clock");
+        assert_eq!(normalize("::"), "");
+    }
+
+    #[rstest]
+    #[case::identical_separators("task-clock/u", "task-clock/u", true)]
+    #[case::slash_pattern_matches_colon_metric("task-clock/u", "task-clock:u", true)]
+    #[case::colon_pattern_matches_slash_metric("task-clock:u", "task-clock/u", true)]
+    #[case::plain_pattern_matches_trailing_colon_metric("task-clock", "task-clock:", true)]
+    #[case::trailing_slash_pattern_matches_plain_metric("task-clock/", "task-clock", true)]
+    #[case::wildcard_normalizes_separator("task-*:u", "task-clock/u", true)]
+    #[case::character_class_normalizes_separator("task-clock[:/]u", "task-clock/u", true)]
+    #[case::escaped_separator_needs_literal_escape_char(r"task-clock\:u", "task-clock/u", false)]
+    #[case::different_metrics_do_not_match("task-clock/u", "cpu-clock:u", false)]
+    fn test_matches_normalizes_separators(
+        #[case] pattern: &str,
+        #[case] metric: &str,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(matches(pattern, metric), expected);
+    }
+}

--- a/crates/gungraun-runner/src/runner/perf/records.rs
+++ b/crates/gungraun-runner/src/runner/perf/records.rs
@@ -8,15 +8,13 @@ use std::path::Path;
 use anyhow::Result;
 use approx::abs_diff_eq;
 use log::trace;
-use simplematch::{DoWild, Options};
 
 use crate::api::{PerfMetric, Unit};
 use crate::metrics::logic::MetricValue as _;
 use crate::metrics::model::{AnnotatedMetric, Metric, Metrics, PerfQualities};
 use crate::runner::perf::model::PerfStatRecord;
+use crate::runner::perf::pattern;
 use crate::stats::runner::{OnlineStatsMap, Stats};
-
-const DOWILD_OPTIONS: Options<u8> = Options::new().enable_escape(true).enable_classes(true);
 
 struct MetricsParser {
     first: Option<(PerfMetric, bool)>,
@@ -279,7 +277,7 @@ impl MetricsParser {
         if float == 0.0
             && non_zero_metrics
                 .iter()
-                .any(|n| n.as_str().dowild_with(key.name(), DOWILD_OPTIONS))
+                .any(|n| pattern::matches(n, key.name()))
         {
             trace!(
                 "Found invalid perf measurement '{}': '{float}' == 0.0",

--- a/crates/gungraun-runner/src/runner/perf/regression.rs
+++ b/crates/gungraun-runner/src/runner/perf/regression.rs
@@ -35,10 +35,10 @@
 use either_or_both::EitherOrBoth;
 use indexmap::IndexMap;
 use log::{info, warn};
-use simplematch::{DoWild, Options};
 
 use crate::api::{self, PerfMetric};
 use crate::metrics::model::{AnnotatedMetric, Metric, MetricKind, MetricsSummary, PerfQualities};
+use crate::runner::perf::pattern;
 use crate::runner::tool::config::resolve_perf_alpha;
 use crate::runner::tool::regression::{
     DEFAULT_REGRESSION_FAIL_FAST, RegressionConfig, RegressionMetrics,
@@ -46,11 +46,6 @@ use crate::runner::tool::regression::{
 use crate::stats::runner::DiffStats;
 use crate::summary::model::ToolRegression;
 use crate::units::Unit;
-
-const DOWILD_OPTIONS: Options<u8> = Options::new()
-    .case_insensitive(true)
-    .enable_escape(true)
-    .enable_classes(true);
 
 /// The perf regression check configuration
 #[derive(Debug, Clone, PartialEq)]
@@ -89,7 +84,7 @@ impl PerfRegressionConfig {
             metrics_summary
                 .all_diffs()
                 .filter_map(move |(metric, metrics_diff)| {
-                    if !pattern.name().dowild_with(metric.name(), DOWILD_OPTIONS) {
+                    if !pattern::matches(pattern.name(), metric.name()) {
                         return None;
                     }
 
@@ -147,7 +142,7 @@ impl PerfRegressionConfig {
                 metrics_summary
                     .all_diffs()
                     .filter_map(move |(metric, metrics_diff)| {
-                        if !pattern.name().dowild_with(metric.name(), DOWILD_OPTIONS) {
+                        if !pattern::matches(pattern.name(), metric.name()) {
                             return None;
                         }
 
@@ -516,5 +511,22 @@ mod tests {
         };
 
         assert_eq!(unit, Some(&Unit::Milliseconds));
+    }
+
+    #[test]
+    fn test_soft_limit_matches_slash_pattern_to_colon_metric() {
+        let config = PerfRegressionConfig {
+            alpha: DEFAULT_PERF_ALPHA,
+            fail_fast: false,
+            soft_limits: vec![(PerfMetric("task-clock/u".to_owned()), 50.0)],
+            hard_limits: vec![],
+        };
+        let summary = perf_summary(
+            "task-clock:u",
+            AnnotatedMetric::with_default_qualities(2000, Unit::Milliseconds),
+            AnnotatedMetric::with_default_qualities(1000, Unit::Milliseconds),
+        );
+
+        assert_eq!(config.check(&summary).len(), 1);
     }
 }

--- a/crates/gungraun-runner/src/runner/tasks.rs
+++ b/crates/gungraun-runner/src/runner/tasks.rs
@@ -806,25 +806,29 @@ mod tests {
     fn test_process_child_wait_with_timeout_waits_for_readiness() {
         let temp_dir = tempfile::tempdir().unwrap();
         let output_path = temp_dir.path().join("perf.out");
+
         let delayed_output_path = output_path.clone();
+
+        let start = Instant::now();
         let output_thread = thread::spawn(move || {
-            sleep(Duration::from_millis(50));
+            sleep(Duration::from_millis(500));
             std::fs::File::create(delayed_output_path).unwrap();
         });
+
         let child = Command::new("sleep").arg("1").spawn().unwrap();
-        let start = Instant::now();
 
         let output = ProcessChild(child)
             .wait(
                 &Arc::new(AtomicBool::new(false)),
-                Duration::from_millis(1),
-                Some(Duration::from_millis(10)),
+                Duration::from_millis(10),
+                Some(Duration::from_millis(50)),
                 Some(&|| output_path.exists()),
             )
             .unwrap();
 
         output_thread.join().unwrap();
-        assert!(start.elapsed() >= Duration::from_millis(50));
+
+        assert!(start.elapsed() >= Duration::from_millis(500));
         assert_eq!(output.status.signal(), Some(signal::SIGTERM as i32));
     }
 

--- a/crates/gungraun-tests/tests/fixtures/perf/perf.filtered.out
+++ b/crates/gungraun-tests/tests/fixtures/perf/perf.filtered.out
@@ -1,2 +1,2 @@
-{"event":"event_filtered_01","counter-value":"0.000000","unit":"count","pcnt-running":25.0}
+{"event":"event_filtered:01","counter-value":"0.000000","unit":"count","pcnt-running":25.0}
 {"event":"event_filtered_02","counter-value":"100.000000","unit":"count","pcnt-running":25.0}

--- a/crates/gungraun-tests/tests/test_perf/test_json_parser.rs
+++ b/crates/gungraun-tests/tests/test_perf/test_json_parser.rs
@@ -459,7 +459,7 @@ fn test_perf_filtered_empty_non_zero() {
     let (temp_dir, output_path) = copy_perf_fixtures("filtered");
     let parser = json_parser_f()
         .min_pcnt_running(0.0)
-        .non_zero_metrics(["event_filtered_01"])
+        .non_zero_metrics(["event_filtered/01"])
         .output_path(output_path.clone())
         .fx();
 

--- a/docs/src/cli_and_env/basics.md
+++ b/docs/src/cli_and_env/basics.md
@@ -678,8 +678,7 @@ Options:
             * exp-bbv
             * perf
 
-          The selected tool must be supported on the benchmark target. A target-supported tool must
-          still be available in the execution environment when the benchmark runs.
+          The selected tool must be supported on the benchmark target.
 
           This argument matches the tool case-insensitive. Note that using Cachegrind with this
           option to benchmark library functions needs adjustments to the benchmarking functions with
@@ -712,7 +711,10 @@ Options:
           The tools specified here take precedence over the tools in the benchmarks. The supported
           tools which are allowed here are the same as the ones listed in the documentation of
           --default-tool.
-          Target-unsupported tools are omitted from a benchmark's resolved tool configurations.
+
+          Target-unsupported tools are omitted from a benchmark's resolved tool configurations. For
+          example if `perf` is not available on the target then `perf` benchmarks are ignored. All
+          Valgrind benchmarks are executed as usual.
 
           Examples
             * --tools dhat
@@ -1045,9 +1047,12 @@ Options:
           such as `ms`, `s`, `B`, or `Hz` is a hard limit. Combine soft and hard limits for one
           pattern with `|`.
 
+          In perf metric patterns, `:` and `/` are interchangeable.
+
           Examples:
             * --perf-limits='*instructions*=5%'
             * --perf-limits='*instructions*=5%|1000000,task-clock*=40%|2.5ms'
+            * --perf-limits='task-clock/u=5%' or --perf-limits='task-clock:u=5%'
 
           [env: GUNGRAUN_PERF_LIMITS=]
 


### PR DESCRIPTION
Perf metric names use `:` as a separator (e.g., `task-clock:u`), but users naturally write patterns with `/` (e.g., `task-clock/u`). Previously, `PerfMetric::display()` had its own unsafe logic to normalize `:` → `/`, while pattern matching in `records.rs` and `regression.rs` used raw `dowild_with` without any separator normalization. This meant:
- Patterns with `/` wouldn't match metrics with `:`
- `display()` logic was duplicated and unsafe
- Trailing separators weren't consistently stripped

This PR introduced a dedicated `runner::perf::pattern` module with shared normalization logic:

- **`normalize()`** — Single-pass function that:
  - Replaces `:` with `/` 
  - Strips trailing `/` and `:` separators
  - Used by both display and matching

- **`matches()`** — Case-insensitive wildcard matching with automatic separator normalization on both pattern and metric